### PR TITLE
Test support for rails 4 & rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ env:
 before_script:
 script: bundle exec rake
 rvm:
-- 2.2.3
+  - 2.2.3
+gemfile:
+  - gemfiles/rails_5.gemfile
+  - gemfiles/rails_4.gemfile
 sudo: false
 cache: bundler
 after_success:

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~>4.0'
+
+# Specify your gem's dependencies in hancock.gemspec
+gemspec path: '../'

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~>5.0'
+
+# Specify your gem's dependencies in hancock.gemspec
+gemspec path: '../'

--- a/hancock.gemspec
+++ b/hancock.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri"
   spec.add_dependency "faraday"            # http library
   spec.add_dependency "faraday_middleware" # allows redirects
-  spec.add_dependency "activesupport", "~> 5"
-  spec.add_dependency "activemodel", "~> 5"
+  spec.add_dependency "activesupport", ">= 4"
+  spec.add_dependency "activemodel", ">= 4"
 end


### PR DESCRIPTION
This gem had been bumped to require activesupport ~>5, but still needs to also support 4.

Test both variants with Rails 4 & Rails 5 gemfiles. Move hancock activesupport requirement to >=4 instead of ~>4 or ~>5.

